### PR TITLE
Added two ecto cells which utilize cv::Split to grab color channels.

### DIFF
--- a/modules/opencv/imgproc/CMakeLists.txt
+++ b/modules/opencv/imgproc/CMakeLists.txt
@@ -14,6 +14,8 @@ ectomodule(imgproc
     Scale.cpp
     Scharr.cpp
     Sobel.cpp
+    Split.cpp
+    SplitThree.cpp
     )
 
 link_ecto(imgproc ${OpenCV_LIBS})

--- a/modules/opencv/imgproc/Split.cpp
+++ b/modules/opencv/imgproc/Split.cpp
@@ -1,0 +1,43 @@
+#include <ecto/ecto.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/core/core_c.h>
+#include <iostream>
+#include <vector>
+
+using ecto::tendrils;
+namespace imgproc
+{
+  struct Split
+  {
+    static void
+    declare_params(tendrils& p)
+    {
+      p.declare<int>("n", "The number of the channel to select", 0);
+    }
+    static void
+    declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+    {
+      inputs.declare<cv::Mat>("image", "image.");
+      outputs.declare<cv::Mat>("image", "channel image");
+    }
+    void
+    configure(const tendrils& params, const tendrils& inputs, const tendrils& outputs)
+    {
+      n_ = params["n"];
+      input = inputs["image"];
+      output = outputs["image"];
+    }
+    int
+    process(const tendrils& /*inputs*/, const tendrils& /*outputs*/)
+    {
+      std::vector<cv::Mat> three_channels;
+      cv::split(*input, three_channels);
+      *output = three_channels[*n_];
+
+      return ecto::OK;
+    }
+    ecto::spore<int> n_;
+    ecto::spore<cv::Mat> input, output;
+  };
+}
+ECTO_CELL(imgproc, imgproc::Split, "Split", "Returns the n'th color channel from the image.");

--- a/modules/opencv/imgproc/SplitThree.cpp
+++ b/modules/opencv/imgproc/SplitThree.cpp
@@ -1,0 +1,48 @@
+#include <ecto/ecto.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/core/core_c.h>
+#include <iostream>
+#include <vector>
+
+using ecto::tendrils;
+namespace imgproc
+{
+  struct SplitThree
+  {
+    static void
+    declare_params(tendrils& p)
+    {
+      // p.declare<int>("n", "The number of the channel to select", 0);
+    }
+    static void
+    declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+    {
+      inputs.declare<cv::Mat>("image", "image.");
+      outputs.declare<cv::Mat>("image1", "First channel image");
+      outputs.declare<cv::Mat>("image2", "Second channel image");
+      outputs.declare<cv::Mat>("image3", "Third channel image");
+    }
+    void
+    configure(const tendrils& params, const tendrils& inputs, const tendrils& outputs)
+    {
+      input = inputs["image"];
+      output1 = outputs["image1"];
+      output2 = outputs["image2"];
+      output3 = outputs["image3"];
+    }
+    int
+    process(const tendrils& /*inputs*/, const tendrils& /*outputs*/)
+    {
+      std::vector<cv::Mat> three_channels;
+      cv::split(*input, three_channels);
+      *output1 = three_channels[0];
+      *output2 = three_channels[1];
+      *output3 = three_channels[2];
+
+      return ecto::OK;
+    }
+
+    ecto::spore<cv::Mat> input, output1, output2, output3;
+  };
+}
+ECTO_CELL(imgproc, imgproc::SplitThree, "SplitThree", "Turn an input image into three image planes of the color channels.");


### PR DESCRIPTION
Added two types of ecto cells to split image channels apart.  The first grabs a channel given by an integer.  The second splits all three color channels into cv::Mat's, and is more effificent than pulling each of the channels individually.

I have a couple of test scripts, but I am not sure where they would find a home.
