### PR TITLE
cv_bp: fix cmake findnumpy module

### DIFF
--- a/cells/cv_bp/opencv/Findnumpy.cmake
+++ b/cells/cv_bp/opencv/Findnumpy.cmake
@@ -30,26 +30,16 @@
 # Once done this will define
 #
 # PYTHON_NUMPY_FOUND        - system has numpy development package and it should be used
-# PYTHON_NUMPY_INCLUDE_DIR  - directory where the arrayobject.h header file can be found
+# PYTHON_NUMPY_INCLUDE_DIR  - directory(-ies) that should be include to use numpy headers
 #
 #
 if(PYTHON_EXECUTABLE)
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/determineNumpyPath.py "try: import numpy; print numpy.get_include()\nexcept: pass\n")
     exec_program("${PYTHON_EXECUTABLE}"
                  ARGS "\"${CMAKE_CURRENT_BINARY_DIR}/determineNumpyPath.py\""
-                 OUTPUT_VARIABLE NUMPY_PATH
+                 OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR
                  )
 endif(PYTHON_EXECUTABLE)
-
-find_path(PYTHON_NUMPY_INCLUDE_DIR arrayobject.h
-          "${NUMPY_PATH}/numpy/"
-          "${PYTHON_INCLUDE_PATH}/numpy/"
-          /usr/include/python2.6/numpy/
-          /usr/include/python2.5/numpy/
-          /usr/include/python2.4/numpy/
-          /usr/include/python2.3/numpy/
-          DOC "Directory where the arrayobject.h header file can be found. This file is part of the numpy package"
-    )
 
 if(PYTHON_NUMPY_INCLUDE_DIR)
     set(PYTHON_NUMPY_FOUND 1 CACHE INTERNAL "Python numpy development package is available")


### PR DESCRIPTION
The search for the numpy include directory was incorrectly adding
'numpy' to the end of the path as this is where arrayobject.h is.  The
correct method is to just return what numpy.get_include() returns.
cv_mat.cpp was already correctly expecting this path.
