### PR TITLE
Recursive directory creation for image saver

### DIFF
--- a/cells/opencv/highgui/ImageSaver.cpp
+++ b/cells/opencv/highgui/ImageSaver.cpp
@@ -79,7 +79,7 @@ namespace ecto_opencv
       fs::path p(name);
       fs::path parent(p.parent_path());
       if (!fs::is_directory(parent) && !parent.empty())
-        fs::create_directory(parent);
+        fs::create_directories(parent);
 
       if (!lock_name_->empty())
       {


### PR DESCRIPTION
This lets it emulate `mkdir -p` behaviour. Previously boost fs would throw an exception.
