### PR TITLE
Only add -msse4.2 if it is supported by the compiler

### DIFF
--- a/cells/opencv/features2d/CMakeLists.txt
+++ b/cells/opencv/features2d/CMakeLists.txt
@@ -20,4 +20,8 @@ link_ecto(features2d ${catkin_LIBRARIES}
 )
 
 #For Hamming distance
-set_target_properties(features2d_ectomodule PROPERTIES COMPILE_FLAGS "-msse4.2")
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-msse4.2 GCC_HAS_SSE)
+if(GCC_HAS_SSE)
+  set_target_properties(features2d_ectomodule PROPERTIES COMPILE_FLAGS "-msse4.2")
+endif()


### PR DESCRIPTION
Using CMake's `check_cxx_compiler_flag()`, determine if the compiler supports `-msse4.2` and add it only if it does.

The primary motivation is that the flag is not supported on ARM platforms for obvious reasons, and causes the build to fail. This is currently (01/02/2015) the only `Jade` package not building on ARM in Fedora.

The check does output the result to the console so it can be verified that it is working correctly. Look for `GCC_HAS_SSE`.

Example ARM build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-ecto-opencv_binaryrpm_21_armhfp/1/consoleFull
Example ARM build after patch: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-ecto-opencv_binaryrpm_21_armhfp/3/consoleFull
Example x86 build after patch: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-ecto-opencv_binaryrpm_21_x86_64/3/consoleFull

Thanks,

--scott
