### PR TITLE
Use opencv3 backported imshows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(ecto_opencv)
 
-find_package(catkin REQUIRED ecto opencv_candidate)
-catkin_package(DEPENDS ecto opencv_candidate)
+find_package(catkin REQUIRED ecto opencv_candidate cv_backports)
+catkin_package(DEPENDS ecto opencv_candidate cv_backports)
 
 if(NOT CMAKE_BUILD_TYPE)#Only do this the on the first run, if the build type hasn't been set prior
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/cells/cv_bp/opencv/CMakeLists.txt
+++ b/cells/cv_bp/opencv/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(${bp_opencv_target}
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
   ${OpenCV_LIBS}
+  ${cv_backports_LIBRARIES}
   )
 
 install(TARGETS ${bp_opencv_target}

--- a/cells/cv_bp/opencv/cv_highgui.cpp
+++ b/cells/cv_bp/opencv/cv_highgui.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <fstream>
 #include <opencv2/highgui/highgui.hpp>
+#include <cv_backports/imshow.hpp>
 
 namespace bp = boost::python;
 
@@ -38,7 +39,7 @@ namespace
     if(callback == bp::object())
     {
         PyMCallBackData::callbacks_[windowName] = NULL;
-        cv::setMouseCallback(windowName,NULL,NULL);
+        cv_backports::setMouseCallback(windowName,NULL,NULL);
         return;
     }
     //FIXME get rid of this leak...
@@ -46,7 +47,7 @@ namespace
     d->cb = callback;
     d->udata = userdata;
     PyMCallBackData::callbacks_[windowName] = d;
-    cv::setMouseCallback(windowName,&PyMCallBackData::callback_fn,d);
+    cv_backports::setMouseCallback(windowName,&PyMCallBackData::callback_fn,d);
   }
 }
 namespace opencv_wrappers
@@ -83,7 +84,7 @@ namespace opencv_wrappers
 
   int waitKey(int millis)
   {
-    return 255 & cv::waitKey(millis);
+    return 255 & cv_backports::waitKey(millis);
   }
 
   void wrap_highgui()
@@ -94,9 +95,9 @@ namespace opencv_wrappers
     wrap_video_writer();
 
     //image windows
-    bp::def("imshow", cv::imshow);
+    bp::def("imshow", cv_backports::imshow);
     bp::def("waitKey", waitKey);
-    bp::def("namedWindow", cv::namedWindow);
+    bp::def("namedWindow", cv_backports::namedWindow);
 //CV_EXPORTS void setMouseCallback( const string& windowName, MouseCallback onMouse, void* param=0);
     bp::def("setMouseCallback", setMouseCallback_);
     //image io

--- a/cells/opencv/highgui/CMakeLists.txt
+++ b/cells/opencv/highgui/CMakeLists.txt
@@ -24,4 +24,4 @@ ectomodule(highgui DESTINATION ecto_opencv
     VideoWriter.cpp
     serialization.cpp
     )
-link_ecto(highgui ${OpenCV_LIBS} ${EXTRA_LIB})
+link_ecto(highgui ${OpenCV_LIBS} ${EXTRA_LIB} ${cv_backports_LIBRARIES})

--- a/cells/opencv/highgui/imshow.cpp
+++ b/cells/opencv/highgui/imshow.cpp
@@ -5,6 +5,7 @@
 #include <boost/format.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
+#include <cv_backports/imshow.hpp>
 
 #include <iostream>
 #include <string>
@@ -39,7 +40,7 @@ namespace ecto_opencv
     operator()(const boost::signals2::connection& c) const
     {
       c.disconnect();
-      cv::destroyWindow(name);
+      cv_backports::destroyWindow(name);
     }
     std::string name;
   };
@@ -61,14 +62,14 @@ namespace ecto_opencv
       c.disconnect();
       if (full_screen)
       {
-        cv::namedWindow(name, CV_WINDOW_KEEPRATIO);
-        cv::setWindowProperty(name, CV_WND_PROP_FULLSCREEN, true);
+        cv_backports::namedWindow(name, CV_WINDOW_KEEPRATIO);
+        cv_backports::setWindowProperty(name, CV_WND_PROP_FULLSCREEN, true);
       }
       else if (auto_size)
       {
-        cv::namedWindow(name, CV_WINDOW_KEEPRATIO);
+        cv_backports::namedWindow(name, CV_WINDOW_KEEPRATIO);
       }
-      cv::imshow(name, image);
+      cv_backports::imshow(name, image);
     }
     const cv::Mat image;
     std::string name;
@@ -97,11 +98,11 @@ namespace ecto_opencv
     void
     operator()()
     {
-      cv::startWindowThread();
+      cv_backports::startWindowThread();
       while (!boost::this_thread::interruption_requested())
       {
         jobs();
-        lastKey = 0xff & cv::waitKey(10);
+        lastKey = 0xff & cv_backports::waitKey(10);
         keys[lastKey] = true;
       }
     }

--- a/cells/opencv/highgui/imshow.cpp
+++ b/cells/opencv/highgui/imshow.cpp
@@ -5,7 +5,21 @@
 #include <boost/format.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
+
+#ifdef CV_VERSION_EPOCH
+#if CV_VERSION_EPOCH == 2 && CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR < 10
 #include <cv_backports/imshow.hpp>
+#else
+namespace cv_backports {
+  using cv::destroyWindow;
+  using cv::imshow;
+  using cv::namedWindow;
+  using cv::setWindowProperty;
+  using cv::startWindowThread;
+  using cv::waitKey;
+}
+#endif
+#endif
 
 #include <iostream>
 #include <string>

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,12 @@
   <build_depend>boost</build_depend>
   <build_depend>ecto</build_depend>
   <build_depend>opencv_candidate</build_depend>
+  <build_depend>cv_backports</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>ecto</run_depend>
   <run_depend>opencv_candidate</run_depend>
+  <run_depend>cv_backports</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 </package>


### PR DESCRIPTION
Just posting this pull request to initiate a discussion (for now).

This is an update to use the underlying [cv_backports](http://wiki.ros.org/cv_backports) 3rd party ros package to provide opencv3 style imshow windows with

* zoom
* toolbar
* parallel thread support

The latter is so you can do opencv style debugging when running multi-threaded ecto schedulers (or even from a background thread). Without this, they crash on X.

Note 1: cv_backports uses the same code submitted to opencv3 for qt imshows.
Note 2: only change here is a namespace change for the relevant api.

This is obviously for an indigo (and potentially up to the rosdistro that supports opencv3) release - problem here is that the master branch spans multiple ros distros. Solution would be to have a indigo only release branch. @vrabaud can we move this way? 
