### PR TITLE
Adding cv_backports to package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(ecto_opencv)
 
-find_package(cv_backports QUIET)
-if(cv_backports_FOUND)
-find_package(catkin REQUIRED ecto opencv_candidate cv_backports)
-catkin_package(DEPENDS ecto opencv_candidate cv_backports)
+find_package(catkin REQUIRED ecto opencv_candidate)
+catkin_package(DEPENDS ecto opencv_candidate)
 else()
 find_package(catkin REQUIRED ecto opencv_candidate)
 catkin_package(DEPENDS ecto opencv_candidate)

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,12 @@
   <build_depend>boost</build_depend>
   <build_depend>ecto</build_depend>
   <build_depend>opencv_candidate</build_depend>
+  <build_depend>cv_backports</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>ecto</run_depend>
   <run_depend>opencv_candidate</run_depend>
+  <run_depend>cv_backports</run_depend>
 
   <test_depend>rosunit</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -12,12 +12,10 @@
   <build_depend>boost</build_depend>
   <build_depend>ecto</build_depend>
   <build_depend>opencv_candidate</build_depend>
-  <build_depend>cv_backports</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>ecto</run_depend>
   <run_depend>opencv_candidate</run_depend>
-  <run_depend>cv_backports</run_depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
Otherwise I get the error:

```
CMake Error at /opt/ros/indigo/share/catkin/cmake/catkin_package.cmake:189 (message):
  catkin_package() the catkin package 'cv_backports' has been
  find_package()-ed but is not listed as a build dependency in the
  package.xml
```