### PR TITLE
Adapt to support boost 1.65

### DIFF
--- a/cells/cv_bp/opencv/cv_mat.cpp
+++ b/cells/cv_bp/opencv/cv_mat.cpp
@@ -4,6 +4,15 @@
 #include <boost/python/stl_iterator.hpp>
 #include <boost/format.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+// Boost python numpy available in Boost 1.63+
+// Boost python numeric removed in Boost 1.65+
+#if BOOST_VERSION < 106500
+#include <boost/python/numeric.hpp>
+typedef typename boost::python::numeric::array NumpyArrayType;
+#else
+#include <boost/python/numpy.hpp>
+typedef typename boost::python::numpy::ndarray NumpyArrayType;
+#endif
 
 #include <string>
 
@@ -81,16 +90,16 @@ namespace
     }
 
     //Create a Numeric array with dimensions dimens and Numeric type t
-    bp::numeric::array
+    NumpyArrayType
     makeNum(std::vector<int> dimens, PyArray_TYPES t = PyArray_DOUBLE)
     {
       using namespace bp;
       object obj(handle<>(PyArray_FromDims(dimens.size(), &dimens[0], t)));
-      return extract<numeric::array>(obj);
+      return extract<NumpyArrayType>(obj);
     }
 
     void*
-    data(bp::numeric::array arr)
+    data(NumpyArrayType arr)
     {
       if (!PyArray_Check(arr.ptr()))
       {
@@ -102,7 +111,7 @@ namespace
 
     //Copy data into the array
     void
-    copy_data(boost::python::numeric::array arr, const uchar* new_data)
+    copy_data(NumpyArrayType arr, const uchar* new_data)
     {
       uchar* arr_data = (uchar*) data(arr);
       size_t nbytes = PyArray_NBYTES(arr.ptr());
@@ -114,7 +123,7 @@ namespace
 
     //Copy data into the array
     void
-    copy_data(uchar* new_data, boost::python::numeric::array arr)
+    copy_data(uchar* new_data, NumpyArrayType arr)
     {
       uchar* arr_data = (uchar*) data(arr);
       size_t nbytes = PyArray_NBYTES(arr.ptr());
@@ -124,14 +133,14 @@ namespace
       }
     }
     PyArray_TYPES
-    type(bp::numeric::array arr)
+    type(NumpyArrayType arr)
     {
       return PyArray_TYPES(PyArray_TYPE(arr.ptr()));
     }
 
     //Return the number of dimensions
     int
-    rank(bp::numeric::array arr)
+    rank(NumpyArrayType arr)
     {
       using namespace bp;
       //std::cout << "inside rank" << std::endl;
@@ -144,7 +153,7 @@ namespace
     }
 
     std::vector<npy_intp>
-    shape(bp::numeric::array arr)
+    shape(NumpyArrayType arr)
     {
       using namespace bp;
       std::vector<npy_intp> out_dims;
@@ -164,7 +173,7 @@ namespace
   }
 
   void
-  mat_from_array(cv::Mat& m, bp::numeric::array array)
+  mat_from_array(cv::Mat& m, NumpyArrayType array)
   {
     std::vector<npy_intp> shape = numpy_helpers::shape(array);
     int cv_depth = numpy_helpers::fromPyArray_TYPES(numpy_helpers::type(array));
@@ -179,13 +188,13 @@ namespace
   bp::object
   mat_to_array(cv::Mat& m)
   {
-    typedef bp::numeric::array array_t;
+    typedef NumpyArrayType array_t;
     std::vector<int> dim(2);
     dim[0] = m.rows;
     dim[1] = m.cols;
     if(m.channels() != 1)
       dim.push_back(m.channels());
-    bp::numeric::array array(numpy_helpers::makeNum(dim, numpy_helpers::fromCVDepth(m.depth())));
+    NumpyArrayType array(numpy_helpers::makeNum(dim, numpy_helpers::fromCVDepth(m.depth())));
     numpy_helpers::copy_data(array, m.ptr(0));
     return array;
   }
@@ -321,7 +330,7 @@ namespace
     return m.t();
   }
 
-  boost::shared_ptr<cv::Mat> from_numpy( bp::numeric::array array)
+  boost::shared_ptr<cv::Mat> from_numpy( NumpyArrayType array)
   {
     cv::Mat m;
     mat_from_array(m,array);
@@ -336,7 +345,9 @@ namespace opencv_wrappers
   wrap_mat()
   {
     import_array();
-    bp::numeric::array::set_module_and_type("numpy", "ndarray");
+    #if BOOST_VERSION < 106500
+    NumpyArrayType::set_module_and_type("numpy", "ndarray");
+    #endif
 
     typedef std::vector<uchar> buffer_t;
     bp::class_<std::vector<uchar> >("buffer").def(bp::vector_indexing_suite<std::vector<uchar>, false>());


### PR DESCRIPTION
From the Boost 1.65 release notes:
http://www.boost.org/users/history/version_1_65_1.html

> The boost::python::numeric API has been removed, as it is being obsoleted by boost::python::numpy.


I found how to fix it from: https://github.com/mcs07/rdkit/blob/a5358f7744dae13731b28963b5c4c45983331dba/Code/RDBoost/boost_numpy.h

Building stuff for Gentoo pulls the latest Boost and so, this popped.