### PR TITLE
update python wrapper for boost 1.65

### DIFF
--- a/cells/cv_bp/opencv/cv_mat.cpp
+++ b/cells/cv_bp/opencv/cv_mat.cpp
@@ -11,6 +11,9 @@
 
 namespace bp = boost::python;
 
+#include "boost/python/numpy.hpp"
+namespace bn = boost::python::numpy;
+
 namespace
 {
 
@@ -81,16 +84,16 @@ namespace
     }
 
     //Create a Numeric array with dimensions dimens and Numeric type t
-    bp::numeric::array
+    bn::ndarray
     makeNum(std::vector<int> dimens, PyArray_TYPES t = PyArray_DOUBLE)
     {
       using namespace bp;
       object obj(handle<>(PyArray_FromDims(dimens.size(), &dimens[0], t)));
-      return extract<numeric::array>(obj);
+      return extract<bn::ndarray>(obj);
     }
 
     void*
-    data(bp::numeric::array arr)
+    data(bn::ndarray arr)
     {
       if (!PyArray_Check(arr.ptr()))
       {
@@ -102,7 +105,7 @@ namespace
 
     //Copy data into the array
     void
-    copy_data(boost::python::numeric::array arr, const uchar* new_data)
+    copy_data(bn::ndarray arr, const uchar* new_data)
     {
       uchar* arr_data = (uchar*) data(arr);
       size_t nbytes = PyArray_NBYTES(arr.ptr());
@@ -114,7 +117,7 @@ namespace
 
     //Copy data into the array
     void
-    copy_data(uchar* new_data, boost::python::numeric::array arr)
+    copy_data(uchar* new_data, bn::ndarray arr)
     {
       uchar* arr_data = (uchar*) data(arr);
       size_t nbytes = PyArray_NBYTES(arr.ptr());
@@ -124,14 +127,14 @@ namespace
       }
     }
     PyArray_TYPES
-    type(bp::numeric::array arr)
+    type(bn::ndarray arr)
     {
       return PyArray_TYPES(PyArray_TYPE(arr.ptr()));
     }
 
     //Return the number of dimensions
     int
-    rank(bp::numeric::array arr)
+    rank(bn::ndarray arr)
     {
       using namespace bp;
       //std::cout << "inside rank" << std::endl;
@@ -144,7 +147,7 @@ namespace
     }
 
     std::vector<npy_intp>
-    shape(bp::numeric::array arr)
+    shape(bn::ndarray arr)
     {
       using namespace bp;
       std::vector<npy_intp> out_dims;
@@ -164,7 +167,7 @@ namespace
   }
 
   void
-  mat_from_array(cv::Mat& m, bp::numeric::array array)
+  mat_from_array(cv::Mat& m, bn::ndarray array)
   {
     std::vector<npy_intp> shape = numpy_helpers::shape(array);
     int cv_depth = numpy_helpers::fromPyArray_TYPES(numpy_helpers::type(array));
@@ -179,13 +182,13 @@ namespace
   bp::object
   mat_to_array(cv::Mat& m)
   {
-    typedef bp::numeric::array array_t;
+    typedef bn::ndarray array_t;
     std::vector<int> dim(2);
     dim[0] = m.rows;
     dim[1] = m.cols;
     if(m.channels() != 1)
       dim.push_back(m.channels());
-    bp::numeric::array array(numpy_helpers::makeNum(dim, numpy_helpers::fromCVDepth(m.depth())));
+    bn::ndarray array(numpy_helpers::makeNum(dim, numpy_helpers::fromCVDepth(m.depth())));
     numpy_helpers::copy_data(array, m.ptr(0));
     return array;
   }
@@ -321,7 +324,7 @@ namespace
     return m.t();
   }
 
-  boost::shared_ptr<cv::Mat> from_numpy( bp::numeric::array array)
+  boost::shared_ptr<cv::Mat> from_numpy( bn::ndarray array)
   {
     cv::Mat m;
     mat_from_array(m,array);
@@ -336,7 +339,6 @@ namespace opencv_wrappers
   wrap_mat()
   {
     import_array();
-    bp::numeric::array::set_module_and_type("numpy", "ndarray");
 
     typedef std::vector<uchar> buffer_t;
     bp::class_<std::vector<uchar> >("buffer").def(bp::vector_indexing_suite<std::vector<uchar>, false>());


### PR DESCRIPTION
Fix for issue [#45](https://github.com/SoMa-Project/vision/issues/45) **Melodic ROS**, **Ubuntu 18.04** with **Boost 1.65** migration

From **Boost 1.63** arrays are included to `numpy` which is in the python wrapper. Thus namespace change was required. 

Backward compatibility was not checked and should not work, thus a new tag and readme note should be created. The rest of `ecto`, `ecto_pcl`, `ecto_ros`, and `ecto_image_pipeline` 